### PR TITLE
Adding Heat-Lamp Syndrome

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -325,3 +325,33 @@
 				to_chat(affected_mob, "<span class='danger'>You let go of what you were holding.</span>")
 				var/obj/item/I = affected_mob.get_active_held_item()
 				affected_mob.dropItemToGround(I)
+
+/datum/disease/transformation/lizard
+	name = "Heat-Lamp Syndrome"
+	max_stages = 5
+	cure_text = "Milk"
+	cures = list("milk")
+	agent = "lizard tears"
+	desc = "This disease turns its victim into a small lizard."
+	viable_mobtypes = list(/mob/living/carbon/human)
+	severity = DISEASE_SEVERITY_HARMFUL
+	visibility_flags = 0
+	stage1 = list("You feel dry.")
+	stage2 = list("You feel like following the janitor.")
+	stage3 = list("<span class='danger'>Your skin feels a bit... scaly.</span>")
+	stage4 = list("<span class='danger'>A juicy roach sounds delicious right about now.</span>")
+	stage5 = list("<span class='danger'>It's too cold in here!</span>", "<span class='danger'>You feel small...</span>", "<span class='danger'>Your body cries out for the warmth of a heated stone!</span>")
+	new_form = /mob/living/simple_animal/hostile/lizard
+	var/datum/species/lizard/lizard = new /datum/species/lizard()
+
+/datum/disease/transformation/lizard/stage_act()
+	..()
+	switch(stage)
+		if(3)
+			if (prob(10))
+				affected_mob.say(pick("Hiss!"))
+		if(4)
+			affected_mob.set_species(lizard)
+		if(5)
+			if (prob(20))
+				affected_mob.say(pick("Hisss!", "Ssskree!", "HISSS!!"))


### PR DESCRIPTION

This is a disease I coded a good while ago for Oracle station back before they went under. I decided I may as well drop it off here. This disease slowly turns those who are infected into a tiny lizard. It works in stages, and turns the character into a lizardperson before finally turning the victim into a tiny lizard mob. The cure for this disease is milk, every stage has its own flavor text, and it does not spread itself to other crewmembers. It is a fun disease for admins to use as they see fit, and could provide some fun events in the near future!

## Changelog
:cl: Battletrap360
add: Added Heat-Lamp Syndrome, a disease that turns its victims into small, helpless lizards!
/:cl:
